### PR TITLE
Fix: 취소 모달 수정 사항 반영

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "react": "^18.2.0",
         "react-daum-postcode": "^3.1.3",
         "react-dom": "^18.2.0",
+        "react-error-boundary": "^4.0.12",
         "react-hook-form": "^7.45.2",
         "react-redux": "^8.1.2",
         "react-responsive": "^9.0.2",
@@ -13542,6 +13543,17 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.12.tgz",
+      "integrity": "sha512-kJdxdEYlb7CPC1A0SeUY38cHpjuu6UkvzKiAmqmOFL21VRfMhOcWxTCBgLVCO0VEMh9JhFNcVaXlV4/BTpiwOA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-error-overlay": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react": "^18.2.0",
     "react-daum-postcode": "^3.1.3",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^4.0.12",
     "react-hook-form": "^7.45.2",
     "react-redux": "^8.1.2",
     "react-responsive": "^9.0.2",

--- a/src/api/cancleModalApi.ts
+++ b/src/api/cancleModalApi.ts
@@ -1,16 +1,16 @@
 import axiosInstance from './axiosInstance';
 
-interface CancleProps {
+interface CancleContent {
   cancelReason: string;
   content: string;
 }
 
-export const cancleProductAPi = async (cancleProps: CancleProps, orderId: number) => {
-  console.log('api호출: ' + cancleProps);
-  return axiosInstance.post(`/api/orders/${orderId}/cancel`, { cancleProps });
+export const cancleProductAPi = async (orderId: number, body: CancleContent) => {
+  console.log('api호출: ' + body);
+  return axiosInstance.post(`/api/orders/${orderId}/cancel`, { body });
 };
 
 export const getCancleDetailAPi = async (cancelCode: string) => {
   console.log('getCancleDetailAPi');
-  return axiosInstance.get(`/api/orders/${cancelCode}/cancel`, {});
+  return axiosInstance.get(`/api/orders/${cancelCode}/cancel`);
 };

--- a/src/api/cancleModalApi.ts
+++ b/src/api/cancleModalApi.ts
@@ -7,7 +7,7 @@ interface CancleContent {
 
 export const cancleProductAPi = async (orderId: number, body: CancleContent) => {
   console.log('api호출: ' + body);
-  return axiosInstance.post(`/api/orders/${orderId}/cancel`, { body });
+  return axiosInstance.post(`/api/orders/${orderId}/cancel`, body);
 };
 
 export const getCancleDetailAPi = async (cancelCode: string) => {

--- a/src/components/modal/CancleModal.tsx
+++ b/src/components/modal/CancleModal.tsx
@@ -1,15 +1,9 @@
-import React, { useState, useRef, FormEvent, useEffect } from 'react';
-import styled from 'styled-components';
+import React from 'react';
 import Modal, { ModalType } from './Modal';
-import Text from '../common/Text';
-import Spacer from '../common/Spacer';
-import CommonButton, { ButtonType } from '../common/Button';
-import { InputStyle } from '../common/Input';
-import SelectDropDown from '../../components/common/SelectDropDown';
-import { StyledTextArea } from '../../components/common/TextArea';
-import TextBox from '../common/TextBox';
-import { cancleProductAPi } from '../../api/cancleModalApi';
-import { useNavigate } from 'react-router-dom';
+
+import CancleModalForm from './CancleModalForm';
+import { ErrorBoundary } from 'react-error-boundary';
+import ErrorMessage from '../common/ErrorMessage';
 
 export interface CouponModalProps {
   modalOpen: boolean;
@@ -18,99 +12,21 @@ export interface CouponModalProps {
   orderId: number;
 }
 
-const CouponModal: React.FC<CouponModalProps> = ({ modalOpen, modalClose, onCancleSubmit, orderId }) => {
-  const [reasonTitle, setReasonTitle] = useState<string>('');
-  const reasonRef = useRef<HTMLTextAreaElement>(null);
-  const navigate = useNavigate();
-
-  //여기서 api 호출할거니까
-
-  const handleSubmit = async (event: FormEvent) => {
-    event.preventDefault();
-
-    if (reasonRef.current) {
-      if (reasonRef.current.value === '') {
-        alert('취소 사유를 선택해주십시오.');
-      } else {
-        onCancleSubmit([reasonTitle, reasonRef.current.value]);
-
-        try {
-          const response = await cancleProductAPi(orderId, {
-            cancelReason: reasonTitle,
-            content: reasonRef.current.value,
-          });
-          if (response.status === 200) {
-            modalClose();
-
-            setTimeout(() => {
-              if (confirm('취소 신청이 완료되었습니다. 취소 내역 상세로 이동하시겠습니까?')) {
-                navigate('/my-page/refund-history');
-              }
-            }, 0);
-          }
-        } catch (error: any) {
-          console.log('오류가 발생하여 취소에 실패했습니다. 다시 시도해주십시오.');
-          alert('오류가 발생하여 취소에 실패했습니다. 다시 시도해주십시오.');
-          setReasonTitle('');
-          modalClose();
-          if (error.response && error.response.status === 400) {
-            //400오류 발생시
-          } else {
-            //서버 오류 발생
-            console.log(error);
-          }
-        }
-      }
-    }
-  };
-
+const CancleModal: React.FC<CouponModalProps> = ({ modalOpen, modalClose, onCancleSubmit, orderId }) => {
   return (
     <>
       <Modal type={ModalType.POPUP} isModalOpen={modalOpen} onClose={modalClose} title="취소 요청">
-        <form onSubmit={handleSubmit}>
-          <Spacer height={38} />
-          <InputItemContainer>
-            <Text $fontType="H3" color="white">
-              취소 사유
-            </Text>
-            <Spacer height={10} />
-            <SelectDropDown
-              menuItems={['단순변심', '배송지연', '주문실수', '서비스 불만족']}
-              setTitle={setReasonTitle}
-              selectTitle="취소 사유 선택"
-            />
-            <InputStyle type="hidden" value={reasonTitle} />
-            <Spacer height={12} />
-            <Text $fontType="H3" color="white">
-              상세 사유 (선택)
-            </Text>
-            <Spacer height={10} />
-            <StyledTextArea
-              name="cancle"
-              placeholder="상세 사유를 입력해주세요.(최대 300자)"
-              width="100%"
-              height="162px"
-              padding="13px"
-              maxLength={300}
-              ref={reasonRef}
-            />
-          </InputItemContainer>
-          <Spacer height={10} />
-          <TextBox width="100%" bgColor="grey90">
-            <Text $fontType="Body04" color="grey30">
-              - 취소관련 안내사항
-            </Text>
-          </TextBox>
-          <Spacer height={89} />
-          <CommonButton width={'100%'} type={ButtonType.Secondary} htmlType="submit">
-            확인
-          </CommonButton>
-        </form>
+        <ErrorBoundary
+          fallback={<ErrorMessage>에러가 발생했습니다. 다시 시도해주세요.</ErrorMessage>}
+          onError={(error, componentStack) => {
+            console.error('에러가 발생했습니다:', error, componentStack);
+          }}
+        >
+          <CancleModalForm modalClose={modalClose} onCancleSubmit={onCancleSubmit} orderId={orderId} />
+        </ErrorBoundary>
       </Modal>
     </>
   );
 };
 
-export default CouponModal;
-
-const InputItemContainer = styled.div``;
+export default CancleModal;

--- a/src/components/modal/CancleModal.tsx
+++ b/src/components/modal/CancleModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, FormEvent } from 'react';
+import React, { useState, useRef, FormEvent, useEffect } from 'react';
 import styled from 'styled-components';
 import Modal, { ModalType } from './Modal';
 import Text from '../common/Text';
@@ -35,23 +35,21 @@ const CouponModal: React.FC<CouponModalProps> = ({ modalOpen, modalClose, onCanc
         onCancleSubmit([reasonTitle, reasonRef.current.value]);
 
         try {
-          const response = await cancleProductAPi(
-            { cancelReason: reasonTitle, content: reasonRef.current.value },
-            orderId,
-          );
+          const response = await cancleProductAPi(orderId, {
+            cancelReason: reasonTitle,
+            content: reasonRef.current.value,
+          });
           if (response.status === 200) {
-            const { accessToken } = response.data.result;
-            localStorage.setItem('accessToken', accessToken);
             modalClose();
 
             setTimeout(() => {
               if (confirm('취소 신청이 완료되었습니다. 취소 내역 상세로 이동하시겠습니까?')) {
-                navigate('/my-page/defnru - history');
+                navigate('/my-page/refund-history');
               }
             }, 0);
           }
         } catch (error: any) {
-          console.error(error.response);
+          console.log('오류가 발생하여 취소에 실패했습니다. 다시 시도해주십시오.');
           alert('오류가 발생하여 취소에 실패했습니다. 다시 시도해주십시오.');
           setReasonTitle('');
           modalClose();
@@ -98,7 +96,7 @@ const CouponModal: React.FC<CouponModalProps> = ({ modalOpen, modalClose, onCanc
             />
           </InputItemContainer>
           <Spacer height={10} />
-          <TextBox width="100%">
+          <TextBox width="100%" bgColor="grey90">
             <Text $fontType="Body04" color="grey30">
               - 취소관련 안내사항
             </Text>

--- a/src/components/modal/CancleModalForm.tsx
+++ b/src/components/modal/CancleModalForm.tsx
@@ -1,0 +1,109 @@
+import React, { useState, useRef, FormEvent, useEffect } from 'react';
+import styled from 'styled-components';
+import Modal, { ModalType } from './Modal';
+import Text from '../common/Text';
+import Spacer from '../common/Spacer';
+import CommonButton, { ButtonType } from '../common/Button';
+import { InputStyle } from '../common/Input';
+import SelectDropDown from '../../components/common/SelectDropDown';
+import { StyledTextArea } from '../../components/common/TextArea';
+import TextBox from '../common/TextBox';
+import { cancleProductAPi } from '../../api/cancleModalApi';
+import { useNavigate } from 'react-router-dom';
+
+export interface CouponModalProps {
+  modalClose: () => void;
+  onCancleSubmit: (cancleReason: string[]) => void;
+  orderId: number;
+}
+
+const CancleModalForm: React.FC<CouponModalProps> = ({ modalClose, onCancleSubmit, orderId }) => {
+  const [reasonTitle, setReasonTitle] = useState<string>('');
+  const reasonRef = useRef<HTMLTextAreaElement>(null);
+  const navigate = useNavigate();
+  const [apiError, setApiError] = useState<boolean>(false);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+
+    if (reasonRef.current) {
+      if (reasonRef.current.value === '') {
+        alert('취소 사유를 선택해주십시오.');
+      } else {
+        onCancleSubmit([reasonTitle, reasonRef.current.value]);
+
+        try {
+          const response = await cancleProductAPi(orderId, {
+            cancelReason: reasonTitle,
+            content: reasonRef.current.value,
+          });
+          if (response.status === 200) {
+            modalClose();
+
+            setTimeout(() => {
+              if (confirm('취소 신청이 완료되었습니다. 취소 내역 상세로 이동하시겠습니까?')) {
+                navigate('/my-page/refund-history');
+              }
+            }, 0);
+          }
+        } catch (error: any) {
+          setReasonTitle('');
+          setApiError(true); //여기서 에러 발생했음을 설정
+        }
+      }
+    }
+  };
+
+  //ErrorBoundary 감지를 위해서 Error를 직접 날림
+  useEffect(() => {
+    if (apiError) {
+      throw new Error('api요청 실패');
+    }
+  }, [apiError]);
+
+  return (
+    <>
+      <form onSubmit={handleSubmit}>
+        <Spacer height={38} />
+        <div>
+          <Text $fontType="H3" color="white">
+            취소 사유
+          </Text>
+          <Spacer height={10} />
+          <SelectDropDown
+            menuItems={['단순변심', '배송지연', '주문실수', '서비스 불만족']}
+            setTitle={setReasonTitle}
+            selectTitle="취소 사유 선택"
+          />
+          <InputStyle type="hidden" value={reasonTitle} />
+          <Spacer height={12} />
+          <Text $fontType="H3" color="white">
+            상세 사유 (선택)
+          </Text>
+          <Spacer height={10} />
+          <StyledTextArea
+            name="cancle"
+            placeholder="상세 사유를 입력해주세요.(최대 300자)"
+            width="100%"
+            height="162px"
+            padding="13px"
+            maxLength={300}
+            ref={reasonRef}
+          />
+        </div>
+        <Spacer height={10} />
+        <TextBox width="100%" bgColor="grey90">
+          <Text $fontType="Body04" color="grey30">
+            - 취소관련 안내사항
+          </Text>
+        </TextBox>
+        <Spacer height={89} />
+        <CommonButton width={'100%'} type={ButtonType.Secondary} htmlType="submit">
+          확인
+        </CommonButton>
+      </form>
+    </>
+  );
+};
+
+export default CancleModalForm;

--- a/src/components/modal/CancleModalForm.tsx
+++ b/src/components/modal/CancleModalForm.tsx
@@ -1,6 +1,4 @@
 import React, { useState, useRef, FormEvent, useEffect } from 'react';
-import styled from 'styled-components';
-import Modal, { ModalType } from './Modal';
 import Text from '../common/Text';
 import Spacer from '../common/Spacer';
 import CommonButton, { ButtonType } from '../common/Button';

--- a/src/constants/orderTestData.ts
+++ b/src/constants/orderTestData.ts
@@ -69,7 +69,7 @@ const orderTestData: OrderItemListProps[] = [
     deliveryFee: 2500,
     discountAmount: 0,
     discountRate: 0,
-    id: 41,
+    id: 42,
     orderAmount: 9882500,
     orderCode: '2023083141',
     orderItems: exOrderItems,


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat/mypage-cancle-api

### 🔑 주요 변경사항
- 오타 수정
- accessToken 삭제
- 불필요한 코드 삭제
- 타입명 변경

### 관련 이슈
- ErrorBoundary 적용하려고 찾아봤는데
    - 오류 경계는 다음에 대한 오류를 포착 하지 않습니다 .
           - 이벤트 핸들러( [자세히 알아보기](https://legacy.reactjs.org/docs/error-boundaries.html#how-about-event-handlers) )
           - 비동기 코드(예 setTimeout: requestAnimationFrame콜백)
           - 서버 측 렌더링
           - 오류 경계 자체(자식 아님)에서 발생하는 오류
   라고 하더라고요.. 그래서 적용 못했습니다...
