### PR TITLE
Feat: 교환/환불 모달창 제출 후 초기화

### DIFF
--- a/src/components/modal/ExRefundApplyBtn.tsx
+++ b/src/components/modal/ExRefundApplyBtn.tsx
@@ -1,21 +1,12 @@
 import CommonButton, { ButtonType } from '../common/Button';
-import { useFormContext } from 'react-hook-form';
 
 interface ExRefundApplyBtnProp {
   onClick: () => void;
 }
 
 const ExRefundApplyBtn: React.FC<ExRefundApplyBtnProp> = ({ onClick }) => {
-  const { getValues, setValue } = useFormContext();
-
-  const onSubmit = () => {
-    //여기에 API 구현 getValues() 이용
-    setValue('items', []); //체크 배열 빈배열로 초기화
-    onClick();
-  };
-
   return (
-    <CommonButton width={'100%'} type={ButtonType.Secondary} onClick={onSubmit}>
+    <CommonButton width={'100%'} type={ButtonType.Secondary} onClick={onClick}>
       확인
     </CommonButton>
   );

--- a/src/components/modal/ExRefundApplyInput.tsx
+++ b/src/components/modal/ExRefundApplyInput.tsx
@@ -70,6 +70,7 @@ const ExRefunApplyInput: React.FC<ExRefundApplyInputProps> = ({ inputString, men
           height="162px"
           padding="13px"
           maxLength={300}
+          id="deatailReason"
           {...register('detailReason')}
         />
         <Spacer height={10} />

--- a/src/components/modal/ExRefundApplyModal.tsx
+++ b/src/components/modal/ExRefundApplyModal.tsx
@@ -34,12 +34,28 @@ const ExRefundApplyModal: React.FC<ExRefundProps> = ({ menuItems, modalOpen, mod
     defaultValues: { items: [], detailReason: '', refundType: ClaimStatus.EXCHANGE },
   });
 
+  const { reset, getValues } = methods;
+
+  const onClick = () => {
+    //여기서 API 호출하는게 나을듯
+
+    console.log(getValues());
+
+    if (getValues('items').length === 0) {
+      alert('상품을 선택하지 않으셨습니다.');
+      return;
+    }
+
+    reset({ items: [], detailReason: '', refundType: ClaimStatus.EXCHANGE });
+    modalClose();
+  };
+
   return (
     <Modal type={ModalType.POPUP} isModalOpen={modalOpen} onClose={modalClose} title="교환/반품 신청">
       <InputContainer>
         <FormProvider {...methods}>
           <ExRefunApplyInput inputString={inputString} menuItems={menuItems} />
-          <ExRefundApplyBtn onClick={modalClose} />
+          <ExRefundApplyBtn onClick={onClick} />
         </FormProvider>
       </InputContainer>
     </Modal>

--- a/src/components/modal/ExRefundApplyModal.tsx
+++ b/src/components/modal/ExRefundApplyModal.tsx
@@ -37,10 +37,7 @@ const ExRefundApplyModal: React.FC<ExRefundProps> = ({ menuItems, modalOpen, mod
   const { reset, getValues } = methods;
 
   const onClick = () => {
-    //여기서 API 호출하는게 나을듯
-
-    console.log(getValues());
-
+    //여기서 API 호출
     if (getValues('items').length === 0) {
       alert('상품을 선택하지 않으셨습니다.');
       return;

--- a/src/components/modal/ExRefundInfoModal.tsx
+++ b/src/components/modal/ExRefundInfoModal.tsx
@@ -26,9 +26,8 @@ const ExRefundInfoModal: React.FC<RefundProps> = ({ modalOpen, inputString, moda
     if (!isCheck) {
       return alert('동의가 필요합니다.');
     }
-
-    modalClose();
     setIsCheck(false);
+    onSubmit();
   };
 
   return (
@@ -57,7 +56,7 @@ const ExRefundInfoModal: React.FC<RefundProps> = ({ modalOpen, inputString, moda
         </Text>
       </CheckBoxBtnContainer>
       <Spacer height={10} />
-      <CommonButton width={'100%'} type={isCheck ? ButtonType.Primary : ButtonType.Secondary} onClick={onSubmit}>
+      <CommonButton width={'100%'} type={isCheck ? ButtonType.Primary : ButtonType.Secondary} onClick={onClick}>
         확인
       </CommonButton>
     </Modal>

--- a/src/components/my/inCard/OrderListButtons.tsx
+++ b/src/components/my/inCard/OrderListButtons.tsx
@@ -54,6 +54,7 @@ const OrderListButtons: FC<OrderListButtonsProps> = ({
 
   const handleRefundInfoSubmitModal = () => {
     setIsRefundApplyOpen(true);
+    setIsRefundInfoOpen(false);
   };
 
   const handleRefundApplyCloseModal = () => {


### PR DESCRIPTION


## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat/mypage-exrefund-modal

### 💡 작업동기
- 제출 하고 나서도 textarea에 상세사유가 지워지지 않고 남아있음
- 제출 후 모든 값 초기화 하도록 수정

### 🔑 주요 변경사항
- reset 함수사용
- 버튼 컴포넌트에서 API 호출 -> 모달 컴포넌트에서 API 호출 (reset함수 사용 위해서)

### 🏞 스크린샷
<제출>
<img width="521" alt="image" src="https://github.com/kyobo-b2b-apple/kyobo-b2b-apple-frontend/assets/55472485/a149fb80-0e2a-4fec-934e-59d6aa81d731">
<제출 후>
<img width="524" alt="image" src="https://github.com/kyobo-b2b-apple/kyobo-b2b-apple-frontend/assets/55472485/33cff1a2-5b63-4849-9000-431ea922899c">

### 관련 이슈
- getValues로 값을 받아오게 짰는데 handleSubmit을 이용하는게 나을까요..?
