### PR TITLE
Feat: 에러페이지

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,6 +66,7 @@ function App() {
             <Route path="/search" element={<SearchPage />} />
             <Route path="/my-page" element={<MyPageLayout />}>
               <Route path="userchange" element={<MyPageUserChangePage />} />
+
               <Route path="/my-page/order-list" element={<OrderList />} />
 
               <Route path="/my-page/delivery-tracking/:orderCode" index element={<DeliveryTracking />} />

--- a/src/components/modal/CancleModal.tsx
+++ b/src/components/modal/CancleModal.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import Modal, { ModalType } from './Modal';
 import CancleModalForm from './CancleModalForm';
 import { ErrorBoundary } from 'react-error-boundary';
-import ErrorMessage from '../common/ErrorMessage';
+import ErrorPage from '../../pages/ErrorPage';
 
 export interface CouponModalProps {
   modalOpen: boolean;
@@ -12,13 +12,18 @@ export interface CouponModalProps {
   orderId: number;
 }
 
-
 const CancleModal: React.FC<CouponModalProps> = ({ modalOpen, modalClose, onCancleSubmit, orderId }) => {
   return (
     <>
       <Modal type={ModalType.POPUP} isModalOpen={modalOpen} onClose={modalClose} title="취소 요청">
         <ErrorBoundary
-          fallback={<ErrorMessage>에러가 발생했습니다. 다시 시도해주세요.</ErrorMessage>}
+          fallback={
+            <ErrorPage
+              errorTitle="연결 오류"
+              errorMessage="오류가 발생했습니다. 다시 시도해 주십시오."
+              isPrevious={false}
+            />
+          }
           onError={(error, componentStack) => {
             console.error('에러가 발생했습니다:', error, componentStack);
           }}

--- a/src/components/modal/ExRefundApplyBtn.tsx
+++ b/src/components/modal/ExRefundApplyBtn.tsx
@@ -1,21 +1,12 @@
 import CommonButton, { ButtonType } from '../common/Button';
-import { useFormContext } from 'react-hook-form';
 
 interface ExRefundApplyBtnProp {
   onClick: () => void;
 }
 
 const ExRefundApplyBtn: React.FC<ExRefundApplyBtnProp> = ({ onClick }) => {
-  const { getValues, setValue } = useFormContext();
-
-  const onSubmit = () => {
-    //여기에 API 구현 getValues() 이용
-    setValue('items', []); //체크 배열 빈배열로 초기화
-    onClick();
-  };
-
   return (
-    <CommonButton width={'100%'} type={ButtonType.Secondary} onClick={onSubmit}>
+    <CommonButton width={'100%'} type={ButtonType.Secondary} onClick={onClick}>
       확인
     </CommonButton>
   );

--- a/src/components/modal/ExRefundApplyInput.tsx
+++ b/src/components/modal/ExRefundApplyInput.tsx
@@ -70,6 +70,7 @@ const ExRefunApplyInput: React.FC<ExRefundApplyInputProps> = ({ inputString, men
           height="162px"
           padding="13px"
           maxLength={300}
+          id="deatailReason"
           {...register('detailReason')}
         />
         <Spacer height={10} />

--- a/src/components/modal/ExRefundApplyModal.tsx
+++ b/src/components/modal/ExRefundApplyModal.tsx
@@ -34,12 +34,28 @@ const ExRefundApplyModal: React.FC<ExRefundProps> = ({ menuItems, modalOpen, mod
     defaultValues: { items: [], detailReason: '', refundType: ClaimStatus.EXCHANGE },
   });
 
+  const { reset, getValues } = methods;
+
+  const onClick = () => {
+    //여기서 API 호출하는게 나을듯
+
+    console.log(getValues());
+
+    if (getValues('items').length === 0) {
+      alert('상품을 선택하지 않으셨습니다.');
+      return;
+    }
+
+    reset({ items: [], detailReason: '', refundType: ClaimStatus.EXCHANGE });
+    modalClose();
+  };
+
   return (
     <Modal type={ModalType.POPUP} isModalOpen={modalOpen} onClose={modalClose} title="교환/반품 신청">
       <InputContainer>
         <FormProvider {...methods}>
           <ExRefunApplyInput inputString={inputString} menuItems={menuItems} />
-          <ExRefundApplyBtn onClick={modalClose} />
+          <ExRefundApplyBtn onClick={onClick} />
         </FormProvider>
       </InputContainer>
     </Modal>

--- a/src/components/modal/ExRefundApplyModal.tsx
+++ b/src/components/modal/ExRefundApplyModal.tsx
@@ -37,10 +37,7 @@ const ExRefundApplyModal: React.FC<ExRefundProps> = ({ menuItems, modalOpen, mod
   const { reset, getValues } = methods;
 
   const onClick = () => {
-    //여기서 API 호출하는게 나을듯
-
-    console.log(getValues());
-
+    //여기서 API 호출
     if (getValues('items').length === 0) {
       alert('상품을 선택하지 않으셨습니다.');
       return;

--- a/src/components/modal/ExRefundInfoModal.tsx
+++ b/src/components/modal/ExRefundInfoModal.tsx
@@ -26,9 +26,8 @@ const ExRefundInfoModal: React.FC<RefundProps> = ({ modalOpen, inputString, moda
     if (!isCheck) {
       return alert('동의가 필요합니다.');
     }
-
-    modalClose();
     setIsCheck(false);
+    onSubmit();
   };
 
   return (
@@ -57,7 +56,7 @@ const ExRefundInfoModal: React.FC<RefundProps> = ({ modalOpen, inputString, moda
         </Text>
       </CheckBoxBtnContainer>
       <Spacer height={10} />
-      <CommonButton width={'100%'} type={isCheck ? ButtonType.Primary : ButtonType.Secondary} onClick={onSubmit}>
+      <CommonButton width={'100%'} type={isCheck ? ButtonType.Primary : ButtonType.Secondary} onClick={onClick}>
         확인
       </CommonButton>
     </Modal>

--- a/src/components/my/inCard/OrderListButtons.tsx
+++ b/src/components/my/inCard/OrderListButtons.tsx
@@ -54,6 +54,7 @@ const OrderListButtons: FC<OrderListButtonsProps> = ({
 
   const handleRefundInfoSubmitModal = () => {
     setIsRefundApplyOpen(true);
+    setIsRefundInfoOpen(false);
   };
 
   const handleRefundApplyCloseModal = () => {

--- a/src/pages/ErrorPage/index.tsx
+++ b/src/pages/ErrorPage/index.tsx
@@ -1,0 +1,83 @@
+import ErrorMessageComponents from '../../components/common/ErrorMessage';
+import CommonButton, { ButtonType } from '../../components/common/Button';
+import { Text } from '../../components/common';
+import styled from 'styled-components';
+import TextBox from '../../components/common/TextBox';
+import { useNavigate } from 'react-router-dom';
+
+interface ErrorProp {
+  errorTitle: string;
+  errorMessage: string;
+  isRefrech?: boolean;
+  isPrevious?: boolean;
+  isHome?: boolean;
+}
+
+const ErrorPage: React.FC<ErrorProp> = ({
+  errorTitle,
+  errorMessage,
+  isRefrech = true,
+  isHome = true,
+  isPrevious = true,
+}) => {
+  const navigate = useNavigate();
+
+  const refreshBtn = () => {
+    window.location.reload();
+  };
+
+  const previousBtn = () => {
+    navigate(-1);
+  };
+
+  const homeBtn = () => {
+    navigate('/');
+  };
+
+  return (
+    <ErrorContainer>
+      <ContentContainer>
+        <Text $fontType="H2" color="red30">
+          {errorTitle}
+        </Text>
+      </ContentContainer>
+      <ContentContainer>
+        <TextBox bgColor="grey90">
+          <ErrorMessageComponents>{errorMessage}</ErrorMessageComponents>
+        </TextBox>
+      </ContentContainer>
+      <ContentContainer>
+        {isRefrech && (
+          <CommonButton onClick={refreshBtn} type={ButtonType.Secondary}>
+            새로고침
+          </CommonButton>
+        )}
+        {isPrevious && (
+          <CommonButton onClick={previousBtn} type={ButtonType.Secondary}>
+            뒤로가기
+          </CommonButton>
+        )}
+        {isHome && (
+          <CommonButton onClick={homeBtn} type={ButtonType.Secondary}>
+            홈으로 가기
+          </CommonButton>
+        )}
+      </ContentContainer>
+    </ErrorContainer>
+  );
+};
+
+export default ErrorPage;
+
+const ErrorContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  gap: 20px;
+`;
+
+const ContentContainer = styled.div`
+  display: flex;
+  gap: 20px;
+  justify-content: center;
+`;


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- Feat/cancle modal errorboundary

### 💡 작업동기
- 에러 바운더리 시 불러올 페이지 작성

### 🔑 주요 변경사항
- 에러 페이지 작성
- 새로고침, 뒤로가기, 홈으로 가기 버튼 생성
- 위 세 가지 버튼은 boolean 값에 따라서 노출 여부가 결정됨
- 에러 제목과 내용은 직접 정할 수 있음 

### 🏞 스크린샷
<img width="534" alt="image" src="https://github.com/kyobo-b2b-apple/kyobo-b2b-apple-frontend/assets/55472485/ba739f06-571a-49ac-b654-41e553358bfd">


### 관련 이슈
- ErrorBoundary를 App.tsx에 어떻게 적용하시라는건지 잘 모르겠습니다...!
- 모달창에서 띄우는 에러페이지에는 뒤로가기가 필요없을것 같아 안보이게 했습니다.